### PR TITLE
Adding DOW offset setting

### DIFF
--- a/app/src/main/java/net/salisburys/dayclock/MainActivity.java
+++ b/app/src/main/java/net/salisburys/dayclock/MainActivity.java
@@ -227,8 +227,10 @@ public class MainActivity extends ActionBarActivity {
             prologueText.setTextColor(iTextColour);
 
             TextView tvDateDOW = (TextView) findViewById(R.id.dateDOW);
+            Integer iDowOffset = Integer.parseInt(sharedPrefs.getString(
+                    "dateTIMEDowOffset", "0"));
             String s_dateDOW = (String) DateFormat.format("EEEE",
-                    System.currentTimeMillis());
+                    System.currentTimeMillis() - (iDowOffset * 3600 * 1000));
             tvDateDOW.setText(s_dateDOW);
             tvDateDOW.setTextSize(TypedValue.COMPLEX_UNIT_DIP, iDOWSize);
             tvDateDOW.setTextColor(iTextColour);

--- a/app/src/main/res/xml/preferences_fragment.xml
+++ b/app/src/main/res/xml/preferences_fragment.xml
@@ -59,6 +59,11 @@
                 android:defaultValue="h:mm a"
                 android:key="dateTIMFormatCust"
                 android:title="Custom (Google for SimpleDateFormat)" />
+            <net.salisburys.dayclock.TextPrefSummary
+                android:defaultValue="0"
+                android:inputType="number"
+                android:key="dateTIMEDowOffset"
+                android:title="DOW hour offset (how many hours after 12am until DOW switches)" />
         </PreferenceCategory>
 
         <PreferenceCategory


### PR DESCRIPTION
This setting allows making the day of week switch at a different time
than midnight. The thinking here is that some folks get up a bit too
early and see "Oh, it's wednesday" when really it's super early
wednesday and they need more sleep.

If this setting is set to "5", then the clock will read "Tuesday" until
5am, and then it switches to "Wednesday."

Default: 0 (disabled).